### PR TITLE
Tilføjede torrentspecificering gennem programargumenter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN go build .
 ENV TORRENT_CLIENT_PORT=42069
 EXPOSE $TORRENT_CLIENT_PORT/tcp
 EXPOSE $TORRENT_CLIENT_PORT/udp
-ENTRYPOINT ./torrenthygge
+ENTRYPOINT ./torrenthygge denmark-latest.osm.pbf.torrent

--- a/hello.go
+++ b/hello.go
@@ -8,11 +8,16 @@ import "strconv"
 import "time"
 
 func main() {
+	if os.Args[1] == "" {
+		fmt.Println("Please specify a torrent file as parameter")
+		os.Exit(1)
+	}
+	torrFile := os.Args[1]
 	cf := torrent.NewDefaultClientConfig()
 	cf.ListenPort, _ = strconv.Atoi(os.Getenv("TORRENT_CLIENT_PORT"))
 	c, _ := torrent.NewClient(cf)
 	defer c.Close()
-	t, _ := c.AddTorrentFromFile("map.torrent")
+	t, _ := c.AddTorrentFromFile(torrFile)
 	torrentBar(t, false)
 	//Kan også laves som c.AddMagnetLink("bedstemagnetlink");
 	<-t.GotInfo()


### PR DESCRIPTION
Nu skal torrents specificeres gennem terminalargumenter ved at tilføje filnavnet efter programmet køres.